### PR TITLE
feat: Use `Read` and `Write`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ encode = []
 
 [dependencies]
 bitflags = "1"
+thiserror = "1.0.30"

--- a/README.md
+++ b/README.md
@@ -25,14 +25,26 @@ features = ["6502"]
 
 ## Example
 
+### Decoding
+
 ```rust
-let assembly = [...];
+use asm::{_6502, Decoder};
+let assembly = [0x65, 0x83, 0x31];
 
-let decoder = asm::Architecture::_6502::decoder(&assembly);
+let mut decoder = _6502::Decoder::new(&assembly[..]);
 
-for instruction in decoder {
-    println!("{:?}", instruction);
-}
+println!("{:?}", decoder.decode())
+```
+
+### Encoding
+
+```rust
+use asm::{_6502, Encoder};
+let mut assembly = [0u8; 1];
+
+let mut encoder = _6502::Encoder::new(&mut assembly[..]);
+
+encoder.encode(_6502::Instruction::BRK(_6502::Addressing::Implied(())));
 ```
 
 #### License


### PR DESCRIPTION
This library is no longer `#[no_std]` until these land in core.
We need `Write` for a not awful `Encoder` interface.
And we use `Read` because it works with most things that you would want
to decode.