### PR TITLE
tests: Allow tests to be run without --all-features

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,4 +77,4 @@ jobs:
       - name: Setup | Cache
         uses: Swatinem/rust-cache@v1
       - name: Build | Test
-        run: cargo test --all-features
+        run: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ all-features = true
 [dependencies]
 bitflags = "1"
 thiserror = "1.0.30"
+
+[dev-dependencies]
+asm = { path = ".", features = ["6502"] }


### PR DESCRIPTION
This is a workaround hack to enable features when running tests.

bors r+